### PR TITLE
Munn/Changing save data functionality a bit

### DIFF
--- a/game/global.gd
+++ b/game/global.gd
@@ -55,7 +55,8 @@ enum WorldSize {
 
 var game_state
 
-# SESSION_DATA
+# Session Metadata
+var world_name: String
 var session_id: int
 var session_seed: int
 var session_data: Dictionary
@@ -82,6 +83,9 @@ func update_globals():
 	overlay_manager = get_tree().get_first_node_in_group("overlay_manager")
 	camera = get_tree().get_first_node_in_group("camera")
 
+
+#region Metadata
+
 func new_seed() -> int:
 	# Set seed as a semi random number (time since unix epoch or whatever)
 	var new_seed = int(Time.get_unix_time_from_system())
@@ -100,6 +104,41 @@ func set_seed(seed: int) -> void:
 
 func get_seed() -> int:
 	return session_seed
+
+func set_world_name(name: String) -> void:
+	world_name = name
+
+func get_world_name() -> String:
+	return world_name
+
+func set_session_id(id: int) -> void:
+	session_id = id
+
+func get_session_id() -> int:
+	return session_id
+
+func set_metadata(metadata: Dictionary):
+	if not metadata.has_all(["world_name", "session_id", "seed", "world_size"]):
+		printerr("WARNING: Attempted to set Global metadata without proper keys!")
+		return
+	
+	world_name = metadata["world_name"]
+	session_id = metadata["session_id"]
+	session_seed = metadata["seed"]
+	current_world_size = metadata["world_size"]
+
+func get_metadata() -> Dictionary:
+	var metadata = {
+		"world_name": world_name,
+		"session_id": session_id,
+		"seed": session_seed,
+		"world_size": current_world_size,
+	}
+	
+	return metadata
+
+#endregion
+
 
 #region Pausing
 

--- a/game/main.gd
+++ b/game/main.gd
@@ -23,8 +23,8 @@ func create_new_world() -> void:
 	Global.terrain_map.generate_map(Global.current_world_size)
 	Global.fog_map.init()
 	
-	# Save data after first world initialization, so we don't end up with 
-	# a save file that has metadata, but no session data
+	# Save metadata and session data together, so we don't end up with one without the other in a save file
+	SessionData.call_deferred("create_new_session_data", Global.get_metadata())
 	SessionData.call_deferred("save_session_data", Global.session_id)
 
 func load_world(session_data: Dictionary) -> void:

--- a/game/scene_loader/scene_loader.gd
+++ b/game/scene_loader/scene_loader.gd
@@ -25,6 +25,11 @@ func _ready():
 
 func transition_to_main_menu():
 	transition_to_packed(MAIN_MENU)
+	
+	await scene_changed
+	
+	# Reset session id when returning to main menu
+	Global.session_id = 0
 
 func transition_to_game(session_data: Dictionary = {}):
 	transition_to_packed(MAIN)
@@ -61,7 +66,6 @@ func transition_to_packed(scene: PackedScene, tween_in_duration = FADE_DURATION 
 			
 			var music: Node = get_tree().get_first_node_in_group("music")
 			if (music):
-				print("STOPPING_MUSIC")
 				music.audio_stream_player.stop()
 			
 			get_tree().change_scene_to_packed(scene)

--- a/game/session_data/session_data.gd
+++ b/game/session_data/session_data.gd
@@ -26,6 +26,8 @@ func create_new_session_data(metadata: Dictionary):
 	config.set_value(SECTION_METADATA, "world_size", metadata["world_size"])
 	
 	config.save(full_path)
+	
+	print("Created new metadata in: ", full_path)
 
 # Save any information that has changed (tiles, structures, enemies, etc.)
 func save_session_data(save_num: int = 1):
@@ -106,7 +108,8 @@ func load_session_data(save_num: int = 1) -> Dictionary:
 	if err != OK:
 		return {}
 	else:
-		print("Loaded session data from: ", full_path)
+		#print("Loaded session data from: ", full_path)
+		pass
 	
 	# Returns if this save slot is empty
 	if not config.has_section(SECTION_METADATA):

--- a/game/structures/city/factory/factory.gd
+++ b/game/structures/city/factory/factory.gd
@@ -19,7 +19,7 @@ func _ready():
 	if (Global.tech_menu.unassigned_tech.size() > 0):
 		tech_slot = Global.tech_menu.unassigned_tech.pick_random()
 		Global.tech_menu.unassigned_tech.erase(tech_slot)
-		print("Assigned factory tech slot: ", tech_slot)
+		#print("Assigned factory tech slot: ", tech_slot)
 
 ## Returns the "height" that the arrow cursor should be above this structure...
 ## One of "low", "medium", and "high".

--- a/game/ui/screen_ui/confirmation_menu/confirmation_menu.gd
+++ b/game/ui/screen_ui/confirmation_menu/confirmation_menu.gd
@@ -9,6 +9,7 @@ signal choice_made(choice: bool)
 @onready var message: RichTextLabel = %Message
 @onready var accept_button: ScreenButton = %AcceptButton
 @onready var decline_button: ScreenButton = %DeclineButton
+@onready var back_button: ScreenButton = %BackButton
 
 @onready var starting_position := position
 
@@ -18,6 +19,7 @@ func _ready() -> void:
 	
 	accept_button.pressed.connect(_accept_pressed)
 	decline_button.pressed.connect(_decline_pressed)
+	back_button.pressed.connect(_back_pressed)
 
 func _accept_pressed() -> void:
 	SfxManager.play_sound_effect("ui_click")
@@ -30,6 +32,10 @@ func _decline_pressed() -> void:
 	ScreenUI.exit_menu()
 	declined.emit()
 	choice_made.emit(false)
+
+func _back_pressed() -> void:
+	SfxManager.play_sound_effect("ui_click")
+	ScreenUI.exit_menu()
 
 ## SCREEN MENU IMPLEMENTATION
 

--- a/game/ui/screen_ui/confirmation_menu/confirmation_menu.tscn
+++ b/game/ui/screen_ui/confirmation_menu/confirmation_menu.tscn
@@ -28,14 +28,24 @@ theme_override_constants/margin_bottom = 16
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainerWrapper/MarginContainer"]
 layout_mode = 2
 
-[node name="Message" type="RichTextLabel" parent="PanelContainerWrapper/MarginContainer/VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="PanelContainerWrapper/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Message" type="RichTextLabel" parent="PanelContainerWrapper/MarginContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
 theme = ExtResource("2_7n8wo")
 bbcode_enabled = true
 text = "Continue?"
 fit_content = true
 scroll_active = false
+
+[node name="BackButton" parent="PanelContainerWrapper/MarginContainer/VBoxContainer/HBoxContainer2" instance=ExtResource("3_v2ufk")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 0
+text = "Back"
 
 [node name="Control" type="Control" parent="PanelContainerWrapper/MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(0, 4)

--- a/game/ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.gd
+++ b/game/ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.gd
@@ -5,12 +5,22 @@ extends PanelContainer
 @onready var day_label: RichTextLabel = %DayLabel
 @onready var seed_label: RichTextLabel = %SeedLabel
 @onready var delete_button: Button = %DeleteButton
+@onready var tree_icon: TextureRect = %TreeIcon
+@onready var icon_animator: AnimationPlayer = %IconAnimator
+@onready var ground_icon: TextureRect = %GroundIcon
+
+const LARGE_TREE_ICON_THRESHOLD: int = 20
+const TILE_SIZE_PX := Vector2i(32, 32)
 
 var has_save_file: bool = false
 var save_num: int
 
 func _ready() -> void:
 	delete_button.pressed.connect(_on_delete_pressed)
+	tree_icon.texture = tree_icon.texture.duplicate()
+	ground_icon.texture = ground_icon.texture.duplicate()
+	
+	ground_icon.texture.region.position.x = randi_range(0, 3) * TILE_SIZE_PX.x
 
 func set_button_info(save_num: int, session_data: Dictionary): 
 	self.save_num = save_num
@@ -37,6 +47,12 @@ func set_button_info(save_num: int, session_data: Dictionary):
 	if save_num == Global.session_id:
 		button.disabled = true
 		delete_button.disabled = true
+	
+	if session_data["tree_map"].size() >= LARGE_TREE_ICON_THRESHOLD:
+		icon_animator.play("large")
+	else:
+		icon_animator.play("small")
+	ground_icon.texture.region.position.y = 0
 
 func set_button_info_empty(save_num: int):
 	delete_button.visible = false
@@ -47,6 +63,9 @@ func set_button_info_empty(save_num: int):
 	seed_label.text = ""
 	
 	button.pressed.connect(_open_new_world_menu)
+	
+	icon_animator.play("stump")
+	ground_icon.texture.region.position.y = TILE_SIZE_PX.y
 
 func _open_new_world_menu() -> void:
 	if Global.game_state == Global.GameState.PLAYING:

--- a/game/ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.gd
+++ b/game/ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.gd
@@ -14,6 +14,8 @@ func _ready() -> void:
 
 func set_button_info(save_num: int, session_data: Dictionary): 
 	self.save_num = save_num
+	button.disabled = false
+	delete_button.disabled = false
 	
 	# Disconnect all callables
 	for connection in button.pressed.get_connections():
@@ -31,6 +33,10 @@ func set_button_info(save_num: int, session_data: Dictionary):
 	day_label.text = "Day " + str(session_data["current_day"])
 	
 	button.pressed.connect(load_game.bind(save_num, session_data))
+	
+	if save_num == Global.session_id:
+		button.disabled = true
+		delete_button.disabled = true
 
 func set_button_info_empty(save_num: int):
 	delete_button.visible = false

--- a/game/ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.tscn
+++ b/game/ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.tscn
@@ -1,17 +1,101 @@
-[gd_scene load_steps=4 format=3 uid="uid://cuc37nusx6e0e"]
+[gd_scene load_steps=13 format=3 uid="uid://cuc37nusx6e0e"]
 
 [ext_resource type="Theme" uid="uid://b6tppincjordy" path="res://ui/main_ui_theme.tres" id="1_yp4uk"]
 [ext_resource type="Script" uid="uid://cgm4o80avttry" path="res://ui/screen_ui/save_and_load_menu/load_menu/load_button/load_button.gd" id="2_x54al"]
+[ext_resource type="Texture2D" uid="uid://55g0x02evm07" path="res://structures/trees/sheets/tree_triangle_sheet.png" id="3_4rqv8"]
+[ext_resource type="Texture2D" uid="uid://nc08yyyg3qtf" path="res://world/proc_gen/world_tiles.png" id="4_i00nt"]
 
-[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_yp4uk"]
-size = Vector2(40, 40)
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4rqv8"]
+bg_color = Color(0.219931, 0.0478519, 0.0204122, 1)
+border_color = Color(0.436703, 0.127744, 0.0713958, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+corner_detail = 1
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_505hy"]
+atlas = ExtResource("4_i00nt")
+region = Rect2(0, 0, 32, 32)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_i00nt"]
+atlas = ExtResource("3_4rqv8")
+region = Rect2(64, 16, 32, 40)
+
+[sub_resource type="Animation" id="Animation_4rqv8"]
+resource_name = "stump"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:texture:region")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(64, 16, 32, 40)]
+}
+
+[sub_resource type="Animation" id="Animation_i00nt"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:texture:region")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(64, 16, 32, 40)]
+}
+
+[sub_resource type="Animation" id="Animation_505hy"]
+resource_name = "small"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:texture:region")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(256, 16, 32, 40)]
+}
+
+[sub_resource type="Animation" id="Animation_ihmnb"]
+resource_name = "large"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:texture:region")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(256, 80, 32, 40)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_5t37b"]
+_data = {
+&"RESET": SubResource("Animation_i00nt"),
+&"large": SubResource("Animation_ihmnb"),
+&"small": SubResource("Animation_505hy"),
+&"stump": SubResource("Animation_4rqv8")
+}
 
 [node name="LoadButton" type="PanelContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_right = -861.0
-offset_bottom = -548.0
+offset_bottom = -588.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_yp4uk")
@@ -35,10 +119,54 @@ theme_override_constants/margin_bottom = 10
 layout_mode = 2
 mouse_filter = 2
 
-[node name="TextureRect" type="TextureRect" parent="MarginContainer/HBoxContainer"]
+[node name="Panel" type="Panel" parent="MarginContainer/HBoxContainer"]
+clip_children = 2
+custom_minimum_size = Vector2(40, 40)
 layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_4rqv8")
+
+[node name="GroundIcon" type="TextureRect" parent="MarginContainer/HBoxContainer/Panel"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 0.7
+anchor_right = 0.5
+anchor_bottom = 0.7
+offset_left = -14.0
+offset_top = -17.0
+offset_right = 26.0
+offset_bottom = 23.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(0.7, 0.7)
+texture = SubResource("AtlasTexture_505hy")
+
+[node name="TreeIcon" type="TextureRect" parent="MarginContainer/HBoxContainer/Panel"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 0.525
+anchor_right = 0.5
+anchor_bottom = 0.525
+offset_left = -11.0
+offset_top = -19.0
+offset_right = 21.0
+offset_bottom = 21.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(0.7, 0.7)
 mouse_filter = 2
-texture = SubResource("PlaceholderTexture2D_yp4uk")
+texture = SubResource("AtlasTexture_i00nt")
+stretch_mode = 5
+
+[node name="IconAnimator" type="AnimationPlayer" parent="MarginContainer/HBoxContainer/Panel"]
+unique_name_in_owner = true
+root_node = NodePath("../TreeIcon")
+libraries = {
+&"": SubResource("AnimationLibrary_5t37b")
+}
 
 [node name="Control" type="Control" parent="MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(4, 0)

--- a/game/ui/screen_ui/save_and_load_menu/load_menu/load_menu.gd
+++ b/game/ui/screen_ui/save_and_load_menu/load_menu/load_menu.gd
@@ -71,15 +71,17 @@ func create_load_button(save_num: int = 1):
 	
 	load_buttons.add_child(load_button)
 
+# Loads session data for this save_num on a separate thread
 func load_button_info_threaded(save_num: int):
 	threads[save_num].start(_get_button_info.bind(save_num))
 
+# Gets session data, returns it
 func _get_button_info(save_num: int):
 	var session_data = SessionData.load_session_data(save_num)
 	call_deferred("_set_button_info", save_num)
 	return session_data
 
-# Munn: Don't call this manually lol
+# Retrieves the session data from _get_button_info(), and sets the load button info
 func _set_button_info(save_num: int):
 	var session_data = threads[save_num].wait_to_finish()
 	var load_button = get_load_button(save_num)

--- a/game/ui/screen_ui/save_and_load_menu/new_world_menu/new_world_menu.gd
+++ b/game/ui/screen_ui/save_and_load_menu/new_world_menu/new_world_menu.gd
@@ -14,6 +14,7 @@ var is_open := false
 @onready var front_left_tree_animation: AnimationPlayer = %FrontLeftTreeAnimation
 @onready var front_right_tree_animation: AnimationPlayer = %FrontRightTreeAnimation
 
+var current_session_id: int = 0
 
 const DEFAULT_WORLD_SIZE: Global.WorldSize = Global.WorldSize.MEDIUM
 var current_world_size: Global.WorldSize = DEFAULT_WORLD_SIZE
@@ -68,7 +69,7 @@ func reset_inputs() -> void:
 	world_name.text = "New Forest"
 
 func _back() -> void:
-	Global.session_id = 0
+	current_session_id = 0
 	ScreenUI.exit_menu()
 
 
@@ -208,11 +209,13 @@ func create_new_world() -> void:
 	Global.current_world_size = current_world_size
 	
 	var metadata := {
-		"session_id": Global.session_id,
+		"session_id": current_session_id,
 		"world_name": world_name.text.strip_edges(),
 		"seed": Global.get_seed(),
 		"world_size": current_world_size
 	}
+	
+	Global.session_id = current_session_id
 	
 	# Create new save
 	SessionData.create_new_session_data(metadata)

--- a/game/ui/screen_ui/save_and_load_menu/new_world_menu/new_world_menu.gd
+++ b/game/ui/screen_ui/save_and_load_menu/new_world_menu/new_world_menu.gd
@@ -205,9 +205,6 @@ func create_new_world() -> void:
 	# Generate a random seed
 	Global.new_seed()
 	
-	# Pass world size to global............ we love horrific coding practices
-	Global.current_world_size = current_world_size
-	
 	var metadata := {
 		"session_id": current_session_id,
 		"world_name": world_name.text.strip_edges(),
@@ -215,9 +212,7 @@ func create_new_world() -> void:
 		"world_size": current_world_size
 	}
 	
-	Global.session_id = current_session_id
-	
-	# Create new save
-	SessionData.create_new_session_data(metadata)
+	# Sets the metadata, but does not save it
+	Global.set_metadata(metadata)
 	
 	SceneLoader.transition_to_tutorial()

--- a/game/world/Fog_Tile_1.png.import
+++ b/game/world/Fog_Tile_1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dw37ytuqi38ns"
-path="res://.godot/imported/fog_tile_1.png-b32adc26a35a4ada4aff7a3e372e32ba.ctex"
+path="res://.godot/imported/Fog_Tile_1.png-49870620ecefbf95dbc75baa78add7a4.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://world/fog_tile_1.png"
-dest_files=["res://.godot/imported/fog_tile_1.png-b32adc26a35a4ada4aff7a3e372e32ba.ctex"]
+source_file="res://world/Fog_Tile_1.png"
+dest_files=["res://.godot/imported/Fog_Tile_1.png-49870620ecefbf95dbc75baa78add7a4.ctex"]
 
 [params]
 

--- a/game/world/Fog_Tiles_1.png.import
+++ b/game/world/Fog_Tiles_1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c2vbw8v7hqbe0"
-path="res://.godot/imported/fog_tiles_1.png-77a0a5b95a0527a1194c69b10c3b3c38.ctex"
+path="res://.godot/imported/Fog_Tiles_1.png-3adc041ad0b7b715fd660693f4b8aaea.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://world/fog_tiles_1.png"
-dest_files=["res://.godot/imported/fog_tiles_1.png-77a0a5b95a0527a1194c69b10c3b3c38.ctex"]
+source_file="res://world/Fog_Tiles_1.png"
+dest_files=["res://.godot/imported/Fog_Tiles_1.png-3adc041ad0b7b715fd660693f4b8aaea.ctex"]
 
 [params]
 

--- a/game/world/proc_gen/decor/City_Decor_1.png.import
+++ b/game/world/proc_gen/decor/City_Decor_1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b4r20eam5ua8m"
-path="res://.godot/imported/city_decor_1.png-8edcf7880fcdfed0ffd078c104d0e74e.ctex"
+path="res://.godot/imported/City_Decor_1.png-be500d7b5454b4e3ed0675b180b11349.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://world/proc_gen/decor/city_decor_1.png"
-dest_files=["res://.godot/imported/city_decor_1.png-8edcf7880fcdfed0ffd078c104d0e74e.ctex"]
+source_file="res://world/proc_gen/decor/City_Decor_1.png"
+dest_files=["res://.godot/imported/City_Decor_1.png-be500d7b5454b4e3ed0675b180b11349.ctex"]
 
 [params]
 

--- a/game/world/proc_gen/structure_map/City_Buildings_1.png.import
+++ b/game/world/proc_gen/structure_map/City_Buildings_1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://biqrko5gffb5j"
-path="res://.godot/imported/city_buildings_1.png-0dc202942be894333b709bb9e9c79cdd.ctex"
+path="res://.godot/imported/City_Buildings_1.png-96e360efd7a1d364b83d29fd0c8f2084.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://world/proc_gen/structure_map/city_buildings_1.png"
-dest_files=["res://.godot/imported/city_buildings_1.png-0dc202942be894333b709bb9e9c79cdd.ctex"]
+source_file="res://world/proc_gen/structure_map/City_Buildings_1.png"
+dest_files=["res://.godot/imported/City_Buildings_1.png-96e360efd7a1d364b83d29fd0c8f2084.ctex"]
 
 [params]
 

--- a/game/world/proc_gen/terrain_map/Chasm_Tile_1.png.import
+++ b/game/world/proc_gen/terrain_map/Chasm_Tile_1.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://e4tojr7l4pr6"
-path="res://.godot/imported/chasm_tile_1.png-ac567ab62f5ff338136db6aff1e11858.ctex"
+path="res://.godot/imported/Chasm_Tile_1.png-4ce8e94bb2d26acf322bb1b25725c39e.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://world/proc_gen/terrain_map/chasm_tile_1.png"
-dest_files=["res://.godot/imported/chasm_tile_1.png-ac567ab62f5ff338136db6aff1e11858.ctex"]
+source_file="res://world/proc_gen/terrain_map/Chasm_Tile_1.png"
+dest_files=["res://.godot/imported/Chasm_Tile_1.png-4ce8e94bb2d26acf322bb1b25725c39e.ctex"]
 
 [params]
 


### PR DESCRIPTION
- Disabled the ability to load/delete the world you are currently in
- Added confirmation screen when loading a different world if you are currently in game
- Fixed the issue where metadata and session data were saved separately
- Changed confirmation menu to also have a "back" button, which does nothing but close the menu
- Replaced placeholder load button icons with slightly dynamic tree + tile textures