### PR TITLE
fix(saveload): Prevents session ID reset on transition to main menu

### DIFF
--- a/game/scene_loader/scene_loader.gd
+++ b/game/scene_loader/scene_loader.gd
@@ -28,8 +28,11 @@ func transition_to_main_menu():
 	
 	await scene_changed
 	
-	# Reset session id when returning to main menu
-	Global.session_id = 0
+	# --- BUG FIX ---
+	# The line 'Global.session_id = 0' has been removed from this function.
+	# The session ID should only be changed when the player actively selects a
+	# different save file from the main menu, not when transitioning to it.
+	# This prevents the game from losing the context of the current save file.
 
 func transition_to_game(session_data: Dictionary = {}):
 	transition_to_packed(MAIN)

--- a/game/ui/game_over/game_over.gd
+++ b/game/ui/game_over/game_over.gd
@@ -12,5 +12,10 @@ func return_to_main_menu():
 
 func retry():
 	SfxManager.play_sound_effect("ui_click")
-	SceneLoader.transition_to_game()
 	
+	# --- BUG FIX ---
+	# Instead of loading a new, empty game session, we now explicitly reload the
+	# session data from the current save file using the existing Global.session_id.
+	# This ensures that when you retry, you are reloading your actual world.
+	var session_to_reload = SessionData.load_session_data(Global.session_id)
+	SceneLoader.transition_to_game(session_to_reload)


### PR DESCRIPTION
Removed the line that resets Global.session_id when returning to the main menu. This preserves the current game's context and prevents a bug where save file data could be inadvertently wiped after a game over.